### PR TITLE
Update regular expression to allow numbers

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -94,7 +94,7 @@ module.exports = function(options) {
             if (!jira) {
               return true;
             }
-            return /^[A-Z]+-[0-9]+$/.test(jira);
+            return /^[A-Z0-9]+-[0-9]+$/.test(jira);
           },
           filter: function(jira) {
             return jira ? jira.toUpperCase() : '';


### PR DESCRIPTION
Some project codes in Jira may contain numbers, so it is necessary to update the regular expression to validate those codes.